### PR TITLE
Flip of broadcast camera display.

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. -->
      <div class="main">
       <div id="publisher-container" class="publisher-section publisher-container remove-on-broadcast">
          <video id="red5pro-publisher"
-            controls autoplay playsinline muted
+            autoplay playsinline muted
             width="100%" height="100%">
          </video>
         <div class="settings-area remove-on-broadcast">

--- a/static/css/watchparty.css
+++ b/static/css/watchparty.css
@@ -206,6 +206,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   }
   */
 
+#red5pro-publisher {
+  transform: scaleX(-1);
+}
+
 .red5pro-publisher {
   max-width: calc(100vw / 5);
   max-height: calc(100vh / 4);


### PR DESCRIPTION
Uses scaleX transform to mirror the camer view for broadcasters. Unfortunately, you have to turn of controls on the video element attributes as those are flipped as well - however, people rarely use the controls on broadcast and are more utilized for playback (subscribers).